### PR TITLE
#3 [feature] mainpage 스크롤로딩(aka 무한스크롤)구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,7 +23,8 @@ function App() {
       <header>
       </header>
       <main>
-        {showState ==='main' || showState == 'usermain' ? <Main isMain={showState}/> : null}
+        {showState ==='main' || showState === 'usermain' || showState === 'searchmain'
+          ? <Main isMain={showState}/> : null}
       </main>
       <footer></footer>
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ function App() {
 
   //메인프레임 선택에 따른 메인 상태변화
   const [showState, setShowState] = useState('main');
+  //const [showState, setShowState] = useState('usermain');
 
   //로그인 => user메인페이지
   const handleLogin = () => {

--- a/src/components/Collection.js
+++ b/src/components/Collection.js
@@ -6,10 +6,11 @@
     return (
         <div className='relative flex items-center'>
             {results.map((val) => (
-                <div key={val.title} className='w-[160px] sm:w-[200px] md:w-[240px] lg:w-[280px] inline-block cursor-point relative p-2'>
+                <div key={val.title} className='w-[160px] sm:w-[200px] md:w-[240px] lg:w-[280px] inline-block cursor-point relative p-2
+                rounded-[4px] hover:bg-sky-300 hover:opacity-80'>
                     <Thumbnail backdrop_path={val.backdrop_path} title={val.title} />
                     <div>
-                        <div className="text-lg font-bold top-200 w-full h-full hover:bg-gray-700 text-black">{val.title}</div>
+                        <div className="text-lg font-bold top-200 w-full h-full text-black">{val.title}</div>
                         <div className="text-sm top-300 w-full h-full text-gray-700">{val.from}</div>
                     </div>
                 </div>

--- a/src/components/Collection.js
+++ b/src/components/Collection.js
@@ -4,9 +4,9 @@
  function Collection({results}){
 
     return (
-        <div className='relative flex items-center'>
+        <div className='relative items-center flex flex-wrap'>
             {results.map((val) => (
-                <div key={val.title} className='w-[160px] sm:w-[200px] md:w-[240px] lg:w-[280px] inline-block cursor-point relative p-2
+                <div key={val.title} className='w-full sm:w-1/2 md:w-1/3 lg:w-1/4 inline-block cursor-point relative p-2
                 rounded-[4px] hover:bg-sky-300 hover:opacity-80'>
                     <Thumbnail backdrop_path={val.backdrop_path} title={val.title} />
                     <div>

--- a/src/components/Collection.js
+++ b/src/components/Collection.js
@@ -1,23 +1,82 @@
  
  import Thumbnail from "./Thumbnail";
+ import { useEffect, useState, useRef} from "react";
  
- function Collection({results}){
+ function Collection({ results }) {
+    const [items, setItems] = useState([]);
+    const [isLoading, setIsLoading] = useState(false); //현재불러오는 아이템이 있는지 상태
+    const [hasMore, setHasMore] = useState(true);
+    const loaderRef = useRef(null); //Intersection Observe를 사용하여 불러올 아이템이 있는지를 감지하기 위함
+  
+    //컴포넌트마운트, isLoading, hasMore 변경시에 옵저버 등록/해제
+    const loadMoreItems = () => {
+        setIsLoading(true);
 
+        //setIsLoading과 동기적으로 실행되지 않도록 하기위한 지연설정
+        setTimeout(() => {
+          const numItemsToLoad = 2; //test 갯수
+          const startIndex = items.length;
+          const endIndex = Math.min(startIndex + numItemsToLoad, results.length);
+          const newItems = results.slice(startIndex, endIndex);
+          setItems((prevItems) => [...prevItems, ...newItems]);
+          setIsLoading(false);
+          setHasMore(endIndex < results.length);
+        }, 200);
+      };
+    
+      useEffect(() => {
+        loadMoreItems();
+      }, []);
+    
+      useEffect(() => {
+        const observer = new IntersectionObserver(
+          ([entry], observer) => {
+            if (entry.isIntersecting && !isLoading && hasMore) {
+              loadMoreItems();
+            }
+          },
+          {
+            //디폴트옵션상태
+            root: null,
+            rootMargin: "0px",
+            threshold: 0,
+          }
+        );
+        if (loaderRef.current) {
+          observer.observe(loaderRef.current);
+        }
+        return () => {
+          const currentLoaderRef = loaderRef.current;
+          if (currentLoaderRef) {
+            observer.unobserve(currentLoaderRef);
+          }
+        };
+      }, [isLoading, hasMore, loadMoreItems]);
+  
     return (
-        <div className='relative items-center flex flex-wrap'>
-            {results.map((val) => (
-                <div key={val.title} className='w-full sm:w-1/2 md:w-1/3 lg:w-1/4 inline-block cursor-point relative p-2
-                rounded-[4px] hover:bg-sky-300 hover:opacity-80'>
-                    <Thumbnail backdrop_path={val.backdrop_path} title={val.title} />
-                    <div>
-                        <div className="text-lg font-bold top-200 w-full h-full text-black">{val.title}</div>
-                        <div className="text-sm top-300 w-full h-full text-gray-700">{val.from}</div>
-                    </div>
-                </div>
-            ))}
-        </div>
+      <div>
+     <ul style={{ display: "flex", flexWrap: "wrap" }}>
+        {items.map((val, index) => (
+          <li key={index} style={{ height:"auto" }} className="sm:w-full md:w-1/3 lg:w-1/4 xl:w-1/4 2xl:w-1/4 w-full ">
+            <div className="inline-block cursor-point relative p-2 rounded-[4px] hover:bg-sky-300 hover:opacity-80">
+              <Thumbnail backdrop_path={val.backdrop_path} title={val.title} />
+              <div>
+                <div className="text-lg font-bold top-200 w-full h-full text-black">{val.title}</div>
+                <div className="text-sm top-300 w-full h-full text-gray-700">{val.from}</div>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
+        {isLoading && <div>Loading...</div>}
+        {!isLoading && hasMore && (
+          <div ref={loaderRef}>Loading..</div>
+        )}
+        {!isLoading && !hasMore && <div>더이상 북마크가 없어요</div>}
+      </div>
     );
- }
+  }
+  
+  export default Collection;
 
- export default Collection;
  

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -17,7 +17,7 @@ function Main(props){
                     {backdrop_path : "TEST THUMNAIL-3.png", title: "테스트북마크에대한제목3", from: "테스트출처3"},
                     {backdrop_path : "TEST THUMNAIL.png", title: "테스트북마크에대한제목1", from: "테스트출처1"},
                     {backdrop_path : "TEST THUMNAIL-2.png", title: "테스트북마크에대한제목2", from: "테스트출처2"},
-                    {backdrop_path : "TEST THUMNAIL-3.png", title: "테스트북마크에대한제목3", from: "테스트출처3"}
+                    {backdrop_path : "TEST THUMNAIL-3.png", title: "테스트북마크에대한제목3", from: "테스트출처3"},
                 ]
                 
     //state에 따라서 메인배너,검색창,출력 visible을 조정한다
@@ -42,12 +42,17 @@ function Main(props){
         {/* 기본메인화면 진입시 */}
         {state.isMain ==='main' 
             && 
-            <div className='inline-block items-center'>
-                <div className='w-[800px]'>
-                    <Slider/>
+            <div>
+                <div className='flex justify-center'>
+                    <div className='w-3/4 self-center'>
+                        <Slider/>
+                    </div>
                 </div>
-                <div className='mt-[70px] mb-[150px] self-center'>
-                    <SearchBar onSerchActed={handleSearching} isMain={state.isMain} isShow={state.isShow}/>
+
+                <div className='flex justify-center'>
+                    <div className='mt-[70px] mb-[150px] self-center w-1/2'>
+                        <SearchBar onSerchActed={handleSearching} isMain={state.isMain} isShow={state.isShow}/>
+                    </div>
                 </div>
 
                 {/*todo  설명이미지가 들어갈만한 자리에 샘플가안 박스 */}

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -13,21 +13,20 @@ function Main(props){
                     {backdrop_path : "TEST THUMNAIL-2.png", title: "테스트북마크에대한제목2", from: "테스트출처2"},
                     {backdrop_path : "TEST THUMNAIL-3.png", title: "테스트북마크에대한제목3", from: "테스트출처3"}
                 ]
-
+                
     //state에 따라서 메인배너,검색창,출력 visible을 조정한다
     const defaultMain = 'main';
-    const [state, setState] = useState({ isMain: props.isMain || defaultMain , isShow: "beforeSearch" });
+    const [state, setState] = useState({ isMain: props.isMain || defaultMain , isShow: "beforeSearch" , isValue : "" });
 
     //메인화면에서 검색이 일어나는경우, 메인검색창으로 visible을 조정한다
-    const changtoSearch = () =>{
-        setState({isMain : "searchmain", isShow: "afterSearch"});
+    const changtoSearch = (searchTerm) =>{
+        setState({isMain : "searchmain", isShow: "afterSearch", isValue : searchTerm});
     }
 
     //todo 검색API는 메인 이곳에서 처리하는게 좋지 않을까?
     const handleSearching = (searchTerm) =>{
-        if(state.isMain === 'main') changtoSearch();
 
-        forSearching(searchTerm);
+        forSearching(searchTerm, () =>{state.isMain === 'main' && changtoSearch(searchTerm) });
     }
 
 
@@ -53,7 +52,7 @@ function Main(props){
         {state.isMain ==='usermain' && <Collection isMain={state.isMain} results={testVal}/>}
 
         {/* 검색화면 진입시 */}
-        {state.isMain ==='searchmain' && <SearchMain isMain={state.isMain} isShow={state.isShow} results={testVal} onSerchActed={handleSearching}/>}
+        {state.isMain ==='searchmain' && <SearchMain isMain={state.isMain} isShow={state.isShow} results={testVal} onSerchActed={handleSearching} isValue={state.isValue}/>}
 
     </div>
     );
@@ -63,7 +62,8 @@ export default Main;
 
 
 //검색을 처리하는 함수
-function forSearching (searchTerm){
+function forSearching (searchTerm, callback){
 
     console.log('여기서 API통신을 해야죠 : '+ searchTerm);
+    callback();
 }

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -11,11 +11,18 @@ function Main(props){
     const testVal =[
                     {backdrop_path : "TEST THUMNAIL.png", title: "테스트북마크에대한제목1", from: "테스트출처1"},
                     {backdrop_path : "TEST THUMNAIL-2.png", title: "테스트북마크에대한제목2", from: "테스트출처2"},
+                    {backdrop_path : "TEST THUMNAIL-3.png", title: "테스트북마크에대한제목3", from: "테스트출처3"},
+                    {backdrop_path : "TEST THUMNAIL.png", title: "테스트북마크에대한제목1", from: "테스트출처1"},
+                    {backdrop_path : "TEST THUMNAIL-2.png", title: "테스트북마크에대한제목2", from: "테스트출처2"},
+                    {backdrop_path : "TEST THUMNAIL-3.png", title: "테스트북마크에대한제목3", from: "테스트출처3"},
+                    {backdrop_path : "TEST THUMNAIL.png", title: "테스트북마크에대한제목1", from: "테스트출처1"},
+                    {backdrop_path : "TEST THUMNAIL-2.png", title: "테스트북마크에대한제목2", from: "테스트출처2"},
                     {backdrop_path : "TEST THUMNAIL-3.png", title: "테스트북마크에대한제목3", from: "테스트출처3"}
                 ]
                 
     //state에 따라서 메인배너,검색창,출력 visible을 조정한다
     const defaultMain = 'main';
+    //const defaultMain = 'main';
     const [state, setState] = useState({ isMain: props.isMain || defaultMain , isShow: "beforeSearch" , isValue : "" });
 
     //메인화면에서 검색이 일어나는경우, 메인검색창으로 visible을 조정한다
@@ -49,7 +56,12 @@ function Main(props){
         }
 
         {/* 유저메인화면 진입시 */}
-        {state.isMain ==='usermain' && <Collection isMain={state.isMain} results={testVal}/>}
+        {state.isMain ==='usermain' 
+        && 
+            <div className='m-[20px] mt-[70px]'>
+                <Collection isMain={state.isMain} results={testVal}/>
+            </div>
+        }
 
         {/* 검색화면 진입시 */}
         {state.isMain ==='searchmain' && <SearchMain isMain={state.isMain} isShow={state.isShow} results={testVal} onSerchActed={handleSearching} isValue={state.isValue}/>}

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -35,7 +35,7 @@ function Main(props){
         }
 
         {/* 유저메인화면 진입시 */}
-        {isMain ==='userMain' && <Collection results={testVal}/>}
+        {isMain ==='usermain' && <Collection results={testVal}/>}
 
         {/* 검색화면 진입시 */}
 

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -1,9 +1,11 @@
 import Slider from './SliderBanner';
 import Collection from './Collection';
 import SearchBar from './SearchBar';
+import SearchMain from './SearchMain';
 import { useState } from 'react';
 
 function Main(props){
+
 
     //Todo  아래 테스트값 API와 연결하기
     const testVal =[
@@ -14,19 +16,32 @@ function Main(props){
 
     //state에 따라서 메인배너,검색창,출력 visible을 조정한다
     const defaultMain = 'main';
-    const [isMain, setisMain]  = useState(props.isMain || defaultMain);
+    const [state, setState] = useState({ isMain: props.isMain || defaultMain , isShow: "beforeSearch" });
+
+    //메인화면에서 검색이 일어나는경우, 메인검색창으로 visible을 조정한다
+    const changtoSearch = () =>{
+        setState({isMain : "searchmain", isShow: "afterSearch"});
+    }
+
+    //todo 검색API는 메인 이곳에서 처리하는게 좋지 않을까?
+    const handleSearching = (searchTerm) =>{
+        if(state.isMain === 'main') changtoSearch();
+
+        forSearching(searchTerm);
+    }
+
 
     return(
     <div>
         {/* 기본메인화면 진입시 */}
-        {isMain ==='main' 
+        {state.isMain ==='main' 
             && 
             <div className='inline-block items-center'>
                 <div className='w-[800px]'>
                     <Slider/>
                 </div>
                 <div className='mt-[70px] mb-[150px] self-center'>
-                    <SearchBar/>
+                    <SearchBar onSerchActed={handleSearching} isMain={state.isMain} isShow={state.isShow}/>
                 </div>
 
                 {/*todo  설명이미지가 들어갈만한 자리에 샘플가안 박스 */}
@@ -35,13 +50,20 @@ function Main(props){
         }
 
         {/* 유저메인화면 진입시 */}
-        {isMain ==='usermain' && <Collection results={testVal}/>}
+        {state.isMain ==='usermain' && <Collection isMain={state.isMain} results={testVal}/>}
 
         {/* 검색화면 진입시 */}
-
+        {state.isMain ==='searchmain' && <SearchMain isMain={state.isMain} isShow={state.isShow} results={testVal} onSerchActed={handleSearching}/>}
 
     </div>
     );
 }
 
 export default Main;
+
+
+//검색을 처리하는 함수
+function forSearching (searchTerm){
+
+    console.log('여기서 API통신을 해야죠 : '+ searchTerm);
+}

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -1,11 +1,11 @@
 import "../index.css";
 import { useState } from 'react';
 
-function SearchBar(){
+function SearchBar(props){
     const [searchVal, setSearchVal] = useState("");
 
     const handleSearchValChg = (event) =>{
-        setSearchVal(event.target.value);
+        setSearchVal(document.getElementById("mainsearchInput").value);
     };
 
     const handleSearchBarKeydown = (event) => {
@@ -14,20 +14,26 @@ function SearchBar(){
 
     const handleSearchButtonOnClick = (event) => {
         //todo API로 서버와 통신
+
+        //상위컴포넌트 호출
+        const searchTerm = document.getElementById("mainsearchInput").value;
+        test(searchTerm);
+    }
+
+    const test = (searchTerm) =>{
+            props.onSerchActed(searchTerm);  
     }
 
     return (
             <div>
-                <form>
-                    <input 
-                        className="rounded-md w-[400px] h-[38px] bg-white border-2 text-center"
-                        id="mainsearchInput" type="text" placeholder="검색어를 입력하세요" defaultValue={""} onChange={handleSearchValChg}/>
-                    <button 
-                        onClick={handleSearchButtonOnClick}
-                        className=" ml-[3px] p-1 w-[50px] h-[36px] bg-sky-600 text-white rounded-md">
-                        검색
-                    </button>
-                </form>
+                <input 
+                    className="rounded-md w-[400px] h-[38px] bg-white border-2 text-center"
+                    id="mainsearchInput" type="text" placeholder="검색어를 입력하세요" defaultValue={""} onChange={handleSearchValChg}/>
+                <button 
+                    onClick={handleSearchButtonOnClick}
+                    className=" ml-[3px] p-1 w-[50px] h-[36px] bg-sky-600 text-white rounded-md">
+                    검색
+                </button>
             </div>
     );
 

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -2,7 +2,7 @@ import "../index.css";
 import { useState } from 'react';
 
 function SearchBar(props){
-    const [searchVal, setSearchVal] = useState("");
+    const [searchVal, setSearchVal] = useState( props.isValue || "");
 
     const handleSearchValChg = (event) =>{
         setSearchVal(document.getElementById("mainsearchInput").value);
@@ -28,7 +28,7 @@ function SearchBar(props){
             <div>
                 <input 
                     className="rounded-md w-[400px] h-[38px] bg-white border-2 text-center"
-                    id="mainsearchInput" type="text" placeholder="검색어를 입력하세요" defaultValue={""} onChange={handleSearchValChg}/>
+                    id="mainsearchInput" type="text" placeholder="검색어를 입력하세요" defaultValue={searchVal} onChange={handleSearchValChg}/>
                 <button 
                     onClick={handleSearchButtonOnClick}
                     className=" ml-[3px] p-1 w-[50px] h-[36px] bg-sky-600 text-white rounded-md">

--- a/src/components/SearchBar.js
+++ b/src/components/SearchBar.js
@@ -27,7 +27,7 @@ function SearchBar(props){
     return (
             <div>
                 <input 
-                    className="rounded-md w-[400px] h-[38px] bg-white border-2 text-center"
+                    className="rounded-md w-4/5 h-[38px] bg-white border-2 text-center"
                     id="mainsearchInput" type="text" placeholder="검색어를 입력하세요" defaultValue={searchVal} onChange={handleSearchValChg}/>
                 <button 
                     onClick={handleSearchButtonOnClick}

--- a/src/components/SearchMain.js
+++ b/src/components/SearchMain.js
@@ -1,0 +1,45 @@
+import SearchBar from "./SearchBar";
+import Collection from "./Collection";
+import { useState } from 'react';
+
+function SearchMain(props){
+
+    //todo 1. 검색창을 달아준다
+    //todo 2. api값을 받아서 출력되는 콜렉션을 노출한다
+
+    //todo 1-1 만약 아직 검색결과값이 없으면 : 검색창은 가운데에뜬다
+    //todo 1-2 검색결과가 있으면 : 검색창은 위에 뜬다
+    //todo 1-3 검색을 했으나 검색결과가 없으면 : 검색창은 위에 뜨고 안내 메세지가 뜬다
+    //state에 따라서 검색창,출력 visible을 조정한다
+    const defaultShow = 'beforeSearch';
+    const [isShow, setisShow]  = useState(props.isShow|| defaultShow);
+
+    const handleSearching= (searchTerm) => {
+        props.onSerchActed(searchTerm);
+      }
+
+    return (
+        <div>
+            {/* 검색전 */}
+            {isShow === 'beforeSearch' 
+                &&
+                <div className='mt-[100px] mb-[150px] self-center'>
+                <SearchBar onSerchActed={handleSearching} isMain={props.isMain}/>
+                <div className="test mt-[20px]">여기뭔가 검색에 대한 설명? 이 있으면?</div> 
+                </div>
+            }
+
+            {/* 검색후 */}
+            {isShow === 'afterSearch' 
+                &&
+                <div className='mt-[30px] mb-[150px] self-center'>
+                <SearchBar onSerchActed={handleSearching}  isMain={props.isMain}/>
+                </div>
+            }
+
+        </div>
+    );
+
+}
+
+export default SearchMain;

--- a/src/components/SearchMain.js
+++ b/src/components/SearchMain.js
@@ -1,6 +1,7 @@
 import SearchBar from "./SearchBar";
 import Collection from "./Collection";
 import { useState } from 'react';
+import isEmpty from './Common/CommonFuntion';
 
 function SearchMain(props){
 
@@ -33,7 +34,21 @@ function SearchMain(props){
             {isShow === 'afterSearch' 
                 &&
                 <div className='mt-[30px] mb-[150px] self-center'>
-                <SearchBar onSerchActed={handleSearching}  isMain={props.isMain} isValue={props.isValue}/>
+                    <SearchBar onSerchActed={handleSearching}  isMain={props.isMain} isValue={props.isValue}/>
+
+                    {!isEmpty(props.results) 
+                    && 
+                        <div className="m-[20px] mt-[40px]">
+                        <Collection results={props.results}/>
+                        </div>
+                    }
+                    {isEmpty(props.results)
+                    &&
+                        <div className=" mt-[50px]">
+                            <span className="text-sky-600">죄송합니다 검색 결과가 없습니다</span>
+                        </div>
+                    }
+
                 </div>
             }
 

--- a/src/components/SearchMain.js
+++ b/src/components/SearchMain.js
@@ -33,7 +33,7 @@ function SearchMain(props){
             {isShow === 'afterSearch' 
                 &&
                 <div className='mt-[30px] mb-[150px] self-center'>
-                <SearchBar onSerchActed={handleSearching}  isMain={props.isMain}/>
+                <SearchBar onSerchActed={handleSearching}  isMain={props.isMain} isValue={props.isValue}/>
                 </div>
             }
 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,15 +7,9 @@ module.exports = {
   ],
   content: [ "./src/**/*.{js,jsx,ts,tsx}", ],
   theme: {
-    extend: {
-      fontSize:{
-        xs:['12px',{lineHeight:'18px'}],
-        sm:['14px',{lineHeight: '22px'}],
-        base:['16px',{lineHeight:'22px'}],
-        lg:['18px',{lineHeight:'24px'}],
-        xl:['28px',{lineHeight:'40px'}],
-      }
-    },
+    Thumbnail:{
+      
+    }
   },
   plugins: [],
 }


### PR DESCRIPTION
## 주요내용
- 검색메인, 유저메인출력보드
- 스크롤로딩
- 사이즈 반응형 일부 구현

## 스크롤로딩 구현
Intersection Observer를 사용하여 
화면 스크롤링이 타겟에 닿았을때 나머지 랜더하게 하는 방식

[api](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
[한국어로된 설명블로그](https://velog.io/@elrion018/실무에서-느낀-점을-곁들인-Intersection-Observer-API-정리)

## 시험방법
1. 메인화면에서 검색버튼을 누르면
2. 테스트더미데이터가 결과로 출력되는 스크롤 화면 노출

## 추가사항
- 테스트가 될 수있도록 회당 로딩 아이템 갯수 2개로 잡아놓음
- 함수호출이 동기적으로 실행되지 않도록 지연설정 되어있음
